### PR TITLE
fix(ci): define NODE_AUTH_TOKEN for setup-node v7 npmrc

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
+    # setup-node v7 no longer exports NODE_AUTH_TOKEN, but still writes an
+    # .npmrc referencing it; yarn v1 aborts on the unresolved variable.
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v7


### PR DESCRIPTION
## Problem

Publish is broken on `main`. Run [`30779817742`](https://github.com/ondecentral/Lucia-Browser-SDK/actions/runs/30779817742) (the v0.10.6 release) died in 12s at `Install dependencies`:

```
yarn install --frozen-lockfile
error Error: Failed to replace env in config: ${NODE_AUTH_TOKEN}
    at envReplace (/usr/local/lib/node_modules/yarn/lib/cli.js:95448:16)
    at NpmRegistry.normalizeConfig …
```

It fails before build, before `npm publish`, before the S3 upload — so nothing shipped.

## Cause

`chore(ci): bump actions/setup-node from 6 to 7` (`41f62d1`).

setup-node v6 exported a placeholder `NODE_AUTH_TOKEN` whenever `registry-url` was set. v7 dropped that, but still writes an `.npmrc` containing `${NODE_AUTH_TOKEN}`. yarn v1 aborts on an unresolvable variable rather than expanding it to empty.

Side-by-side, same workflow, same yarn:

```
# 25584007026 (2026-05-08, setup-node@v6) — SUCCESS
Run yarn install --frozen-lockfile
  NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
  NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX     <-- v6 exported a dummy
  yarn install v1.22.22 … ok

# 30779817742 (2026-08-03, setup-node@v7) — FAILURE
Run yarn install --frozen-lockfile
  NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
                                                <-- v7 exports nothing
  error Failed to replace env in config: ${NODE_AUTH_TOKEN}
```

Note what that dummy value implies: `npm publish --provenance` was never authenticating with a classic token. It uses OIDC trusted publishing, and `XXXXX-XXXXX` only ever satisfied yarn's string interpolation. The variable needs to be *defined*, not valid.

## Fix

Job-level `env` defining `NODE_AUTH_TOKEN`, so both `yarn install` and the `npm publish` steps see it.

`secrets.NPM_TOKEN` already exists on this repo (unused until now). If it has expired — it dates from 2024-07 — swap the value for any non-empty placeholder; OIDC does the real authentication either way, exactly as it did under v6.

## Verification

- YAML parses; `jobs.publish.env` resolves to `{NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}}`, 10 steps intact
- Cannot be exercised locally — the failure only reproduces against the `.npmrc` setup-node generates on the runner. Real proof is re-running Publish after merge.

## After merge

`main` is at `0.10.6` but npm still serves `0.10.5`, and `cdn.luciaprotocol.com/lucia-sdk-latest.min.js` still contains `https://api.clickinsights.xyz` — so the #102 host swap has not reached any client yet.

Re-run Publish Package for the existing v0.10.6 Release run; no new release needed.

## Unrelated, but visible in the same run list

Dependabot's own update jobs are failing — `30779785316` (brace-expansion) and the undici one at 01:52 — with `Failure running container … bin/run update_files`. Full logs need repo write access. Separate from this.
