### PR TITLE
fix(ci): stop exposing npm publish token to dependency install scripts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,11 @@ jobs:
 
     # setup-node v7 no longer exports NODE_AUTH_TOKEN, but still writes an
     # .npmrc referencing it; yarn v1 aborts on the unresolved variable.
+    # Registry auth comes from OIDC trusted publishing, so no real token is
+    # needed here — and a real one would be readable by dependency lifecycle
+    # scripts during install.
     env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NODE_AUTH_TOKEN: unused-oidc-trusted-publishing
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Follow-up to #103. That PR unblocked publishing, but wired the value the wrong way.

## Problem

#103 put the real npm token at **job** level:

```yaml
env:
  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
```

Job-level `env` reaches every step — including `yarn install` and `yarn build`, which execute lifecycle scripts (`postinstall` etc.) from the full transitive dependency tree. A malicious or compromised package anywhere in that tree can read `NODE_AUTH_TOKEN` and exfiltrate a credential with publish rights to `lucia-sdk`. This is the standard npm supply-chain attack path, and it is the one step that does not need a real value.

## Fix

Use a placeholder. `yarn install` only needs the variable to be *defined* so its generated `.npmrc` interpolates; registry auth comes from OIDC trusted publishing.

```yaml
env:
  NODE_AUTH_TOKEN: unused-oidc-trusted-publishing
```

This is exactly what setup-node v6 did — it exported the literal `XXXXX-XXXXX-XXXXX-XXXXX`, and `npm publish --provenance` succeeded against it for every release up to 0.10.5. The token was never doing the authenticating.

Net effect: no secret is readable by dependency code. `AWS_ROLE_ARN`, `AWS_S3_BUCKET` and `DISTRIBUTION` stay as step-scoped inputs, unchanged.

## Verification

- YAML parses; `jobs.publish.env` resolves to `{NODE_AUTH_TOKEN: unused-oidc-trusted-publishing}`, 10 steps intact
- No `secrets.*` reference remains in any `env:` block
- Publish run [`30780450097`](https://github.com/ondecentral/Lucia-Browser-SDK/actions/runs/30780450097) already proved the install fix works end to end (npm `0.10.7`, CDN serving `https://api.luciaprotocol.com`). This PR changes only where the value comes from, not whether install succeeds.

## Consider rotating NPM_TOKEN

Run `30780450097` executed with the real token exposed to install and build. Nothing indicates it was accessed, and the exposure requires a hostile dependency — but the token has been from 2024-07 and is unused for authentication anyway. Rotating or deleting it costs nothing.
